### PR TITLE
Fix typos and outdated docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,8 +30,8 @@ Modeled after Half Life 2's gravity gun.
 - Since the physics are running only in fixed updates but are also
   right in front of the camera, which should run in a variable update,
   you *need* some sort of interpolation to make it look good. Fortunately,
-  Avian has a built-in solution that only requires you to attach 
-  [`TransformInterpolation`](https://docs.rs/bevy_transform_interpolation/0.1.0/bevy_transform_interpolation/interpolation/struct.TransformInterpolation.html) 
+  Avian has a built-in solution that only requires you to attach
+  [`TransformInterpolation`](https://docs.rs/bevy_transform_interpolation/0.1.0/bevy_transform_interpolation/interpolation/struct.TransformInterpolation.html)
   to your props!
 - Only a single object can be picked up per actor at a time.
 - An object cannot be pulled away while it is being held by someone else.
@@ -83,14 +83,12 @@ fn setup(mut commands: Commands) {
     // Actor
     commands.spawn((
         Transform::default(),
-        Visibility::default(),
         AvianPickupActor::default(),
     ));
 
     // Prop
     commands.spawn((
         Transform::default(),
-        Visibility::default(),
         RigidBody::Dynamic,
         Collider::sphere(0.5),
         // Important to prevent jittering
@@ -126,11 +124,11 @@ The [`AvianPickupActor`] holds a lot of configuration options to tweak the behav
 Many of these can be overridden for a specific prop by using components in the [`prop`] module.
 Finally, you can also read the events in the [`output`] module to react to what's happening.
 
-### First Personal Camera
+### First Person Camera
 
-If you want to use a first person perspective for your player and allow him to be an [`AvianPickupActor`],
+If you want to use a first person perspective for your player and allow them to be an [`AvianPickupActor`],
 you need to make sure to move the camera *before* the physics update takes place. Usually, all movement code
-for physicsal entities in the world should be in the fixed timestep, but the camera is a notable exception.
+for physical entities in the world should be in the fixed timestep, but the camera is a notable exception.
 A player will want to have a camera that works as smoothly as possible and updates every frame. That's why you need to place the camera in the last variable timestep schedule before the physics update. You do this like so:
 
 ```rust

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -28,9 +28,10 @@ pub(super) fn plugin(app: &mut App) {
 /// For a first-person game, add this to the camera entity that is under the
 /// player control.
 ///
-/// Requires the entity to also hold [`TransformBundle`].
+/// Requires the entity to also hold a [`Transform`] and [`GlobalTransform`].
 ///
 /// # Example
+///
 /// ```
 /// # use avian_pickup::prelude::*;
 /// # use bevy::prelude::*;
@@ -38,7 +39,7 @@ pub(super) fn plugin(app: &mut App) {
 /// fn setup_camera(mut commands: Commands) {
 ///     commands.spawn((
 ///         Name::new("Player Camera"),
-///         Camera3dBundle::default(),
+///         Camera3d::default(),
 ///         AvianPickupActor::default(),
 ///     ));
 /// }

--- a/src/cooldown.rs
+++ b/src/cooldown.rs
@@ -13,7 +13,7 @@ pub(super) fn plugin(app: &mut App) {
     app.add_systems(PhysicsSchedule, tick.in_set(AvianPickupSystem::TickTimers));
 }
 
-/// Timings taken from [`CWeaponPhysCannon::SecondaryAttack`](https://github.com/ValveSoftware/source-sdk-2013/blob/master/sp/src/game/server/hl2/weapon_physcannon.cpp#L2284)
+/// Timings taken from [`CWeaponPhysCannon::SecondaryAttack`](https://github.com/ValveSoftware/source-sdk-2013/blob/master/src/game/server/hl2/weapon_physcannon.cpp#L2284)
 #[derive(Debug, Clone, Component)]
 pub(crate) struct Cooldown(HashMap<AvianPickupAction, Timer>);
 
@@ -53,8 +53,8 @@ impl Cooldown {
 
     pub(crate) fn hold(&mut self) {
         // Sneakily updated in two places:
-        // - [+ 0.5](https://github.com/ValveSoftware/source-sdk-2013/blob/master/sp/src/game/server/hl2/weapon_physcannon.cpp#L2316)
-        // - [+ 0.4](https://github.com/ValveSoftware/source-sdk-2013/blob/master/sp/src/game/server/hl2/weapon_physcannon.cpp#L2438)
+        // - [+ 0.5](https://github.com/ValveSoftware/source-sdk-2013/blob/master/src/game/server/hl2/weapon_physcannon.cpp#L2316)
+        // - [+ 0.4](https://github.com/ValveSoftware/source-sdk-2013/blob/master/src/game/server/hl2/weapon_physcannon.cpp#L2438)
         // Let's use just 0.4, that feels nicer.
         self.set(AvianPickupAction::Drop, 0.4);
     }

--- a/src/interaction/pull/mod.rs
+++ b/src/interaction/pull/mod.rs
@@ -18,7 +18,7 @@ pub(super) fn plugin(app: &mut App) {
         );
 }
 
-/// Inspired by [`CWeaponPhysCannon::FindObject`](https://github.com/ValveSoftware/source-sdk-2013/blob/master/sp/src/game/server/hl2/weapon_physcannon.cpp#L2497)
+/// Inspired by [`CWeaponPhysCannon::FindObject`](https://github.com/ValveSoftware/source-sdk-2013/blob/master/src/game/server/hl2/weapon_physcannon.cpp#L2497)
 fn find_object(
     mut commands: Commands,
     spatial_query: SpatialQuery,
@@ -100,7 +100,7 @@ fn find_object(
     }
 }
 
-/// Taken from [this snippet](https://github.com/ValveSoftware/source-sdk-2013/blob/master/sp/src/game/server/hl2/weapon_physcannon.cpp#L2607-L2610)
+/// Taken from [this snippet](https://github.com/ValveSoftware/source-sdk-2013/blob/master/src/game/server/hl2/weapon_physcannon.cpp#L2607-L2610)
 fn adjust_impulse_for_mass(mass: ComputedMass) -> f32 {
     if mass.value() < 50.0 {
         (mass.value() + 0.5) * (1.0 / 50.0)

--- a/src/output.rs
+++ b/src/output.rs
@@ -33,7 +33,7 @@ pub struct PropThrown {
 }
 
 /// Event sent when a prop is dropped by an actor.
-/// This is meant for the user to lister to in order to play sound effects, etc.
+/// This is meant for the user to listen to in order to play sound effects, etc.
 /// Sending this has no effect on the prop itself.
 #[derive(Event, Debug, Clone, Copy, PartialEq, Eq, Reflect)]
 #[reflect(Debug, PartialEq)]


### PR DESCRIPTION
- Remove irrelevant `Visibility` component from README usage example (nothing is being rendered, and it's not used for spatial queries)
- Fix some typos in README and in `src/output.rs`
- Fix use of deprecated bundles in `AvianPickupActor` docs
- Fix links that 404